### PR TITLE
feat: OSX対応

### DIFF
--- a/Contents/scripts/siweighteditor/joint_rule_editor.py
+++ b/Contents/scripts/siweighteditor/joint_rule_editor.py
@@ -39,7 +39,7 @@ class SubWindow(qt.SubWindow):
     
     def init_save(self):
         self.dir_path = os.path.join(
-            os.getenv('MAYA_APP_dir'),
+            os.getenv('MAYA_APP_DIR'),
             'Scripting_Files')
         self.start_file = self.dir_path+'/joint_rule_start.json'
         self.middle_file = self.dir_path+'/joint_rule_middle.json'

--- a/Contents/scripts/siweighteditor/lang.py
+++ b/Contents/scripts/siweighteditor/lang.py
@@ -1,24 +1,15 @@
 # -*- coding: utf-8 -*-
-import re
-import os
-import locale
+from maya import cmds
+
+UI_LANGUAGE = cmds.about(uil=True)
+
 
 class Lang(object):
     def __init__(self, en='', ja=''):
         self.jp = ja
         self.en = en
+
     def output(self):
-        lang = 'en'
-        env = re.sub('_.+', '', os.environ.get('MAYA_UI_LANGUAGE', ''))
-        loc = re.sub('_.+', '', locale.getdefaultlocale()[0])
-        env = re.sub('-.+', '', env)
-        loc = re.sub('-.+', '', loc)
-        if loc != '':
-            lang = loc
-        if env != '':
-            lang = env
-        if lang == 'ja' or lang == 'jp':
+        if UI_LANGUAGE == "ja_JP":
             return self.jp
-        if lang == 'en':
-            return self.en
         return self.en

--- a/Contents/scripts/siweighteditor/siweighteditor.py
+++ b/Contents/scripts/siweighteditor/siweighteditor.py
@@ -649,7 +649,7 @@ class WeightEditorWindow(qt.DockWindow):
     def init_save(self):
         temp = __name__.split('.')
         self.dir_path = os.path.join(
-            os.getenv('MAYA_APP_dir'),
+            os.getenv('MAYA_APP_DIR'),
             'Scripting_Files')
         self.w_file = self.dir_path+'/'+temp[-1]+'_window.json'
     

--- a/Contents/scripts/siweighteditor/weight.py
+++ b/Contents/scripts/siweighteditor/weight.py
@@ -361,7 +361,7 @@ def load_joint_label_rules():
     def_right_list_list = [start_r_list, mid_r_list, end_r_list]
     #左右対称設定ファイルからルールをロードする
     dir_path = os.path.join(
-                    os.getenv('MAYA_APP_dir'),
+                    os.getenv('MAYA_APP_DIR'),
                     'Scripting_Files')
     start_file = dir_path+'/joint_rule_start.json'
     middle_file = dir_path+'/joint_rule_middle.json'


### PR DESCRIPTION
Macの10.12.6で動作しなかったため対応を行いました。
具体的な対応内容は以下の通りです。

- MAYA_APP_dirとなっていた部分をMAYA_APP_DIRに修正
-- Macは環境変数の大文字小文字を区別するため、Noneが返ってきてしまっていた
- Langクラスの `locale.getdefaultlocale()` が正しく値を返さないことがあったため、そもそも安全にmayaのaboutの値を使用するつくりに変更

以下の環境で動作環境確認を行いました。
- Mac(10.12.6)
-- Maya2018 Update4
-- Maya2015 SP6
-Windows(7)
-- Maya2018

以上、ご確認いただけると幸いです🙇