### PR TITLE
頂点選択状態でWeight_Symmetrizeを実行すると例外が発生する問題を修正

### DIFF
--- a/Contents/scripts/siweighteditor/symmetrize.py
+++ b/Contents/scripts/siweighteditor/symmetrize.py
@@ -162,8 +162,10 @@ class WeightSymmetrize():
         vertices = cmds.filterExpand(vertices, sm=31)
         meshes = cmds.filterExpand(self.selection, sm=12)
         #メッシュからジョイントラベルを設定
-        cmds.selectMode(o=True)
-        self.all_meshes = cmds.ls(sl=True)
+        if vertices:
+            self.all_meshes = list(set(x.split(".", 1)[0] for x in vertices))
+        else:
+            self.all_meshes = meshes
         if not self.all_meshes:
             return
         #スキンクラスタからジョイントラベルを設定する
@@ -217,9 +219,6 @@ class WeightSymmetrize():
                 self.ezSymWeight(target=self.vtx_R_All+vtx_L, mirror=True)#右から左へ転送
             
             #選択状態を元通りにする
-            cmds.select(self.all_meshes, r=True)
-            cmds.selectMode(component =True)
-            cmds.selectType( pe=False, pv=True, pf=False)
             cmds.select(self.selection, r=True)
         
     #ウェイトミラー


### PR DESCRIPTION
オブジェクトモードでマーキングメニューからVertexを選択し、頂点選択状態でWeight_Symmetrizeを実行すると例外が発生する問題を修正しました。
Maya2018、Maya2019で確認しています。
```
# Traceback (most recent call last):
#   File "C:\Program Files\Autodesk\ApplicationPlugins\SIWeightEditor\Contents\scripts\siweighteditor\qt.py", line 56, in __call__
#     return self.__func(*self.__args, **self.__kwargs)
#   File "C:\Program Files\Autodesk\ApplicationPlugins\SIWeightEditor\Contents\scripts\siweighteditor\symmetrize.py", line 204, in __init__
#     self.vtx_L = self.listEachMesh(vertices, self.all_meshes, negaPosi = 1, plane=0)
#   File "C:\Program Files\Autodesk\ApplicationPlugins\SIWeightEditor\Contents\scripts\siweighteditor\symmetrize.py", line 243, in listEachMesh
#     preID = meshes.index(vtx[0].split('.')[0])#繝｡繝・す繝･蜷阪ｒ蛻､蛻･縺吶ｋ縺溘ａ縺ｮID
# ValueError: u'Obj1' is not in list
```

symmetryze.pyのL165-L166において、上記の状況だと既にオブジェクトモードになっているせいでself.all_meshesが空のリストになってしまい、L243でindexの取得に失敗するのが原因だと思われます。
L165の時点でオブジェクトモードかどうかを判定、一度コンポーネントモードに戻してから処理するという方法も対応可能でかと思いますが、最後の選択モードを戻す部分が厄介なので、そもそもall_meshesの生成方法を変更しています。

以上、ご確認いただけますと幸いです🙏