### PR TITLE
廃止されたException.messageを修正

### DIFF
--- a/Contents/scripts/siweighteditor/freeze.py
+++ b/Contents/scripts/siweighteditor/freeze.py
@@ -53,7 +53,7 @@ def main(mesh=None, pop_zero_poly=False):
         try:
             cmds.select(s, add=True)
         except Exception as e:
-            print(e.message)
+            print('{}'.format(e))
     if zero_mesh and pop_zero_poly:
         msg = msg01.output()+str(len(zero_mesh))
         msg += '\n'+msg02.output()

--- a/Contents/scripts/siweighteditor/joint_rule_editor.py
+++ b/Contents/scripts/siweighteditor/joint_rule_editor.py
@@ -166,7 +166,7 @@ class SubWindow(qt.SubWindow):
                         r_list = save_data.values()
                         self.all_lr_list.append([l_list, r_list])
                 except Exception as e:
-                    print(e.message)
+                    print('{}'.format(e))
                     self.all_lr_list.append(self.def_all_lr_list[i])
             else:
                 self.all_lr_list.append(self.def_all_lr_list[i])

--- a/Contents/scripts/siweighteditor/modeling.py
+++ b/Contents/scripts/siweighteditor/modeling.py
@@ -100,7 +100,7 @@ class ClusterCopy():
                 print(weights)
             #値が取れないときアンドゥするとなぜか直ることがある
             except Exception as e:
-                print(e.message)
+                print('{}'.format(e))
                 cmds.delete(cls)
                 cmds.undo()
                 set_node = cmds.ls(cmds.listHistory(cls, f=True), type='objectSet', l=True)[0]

--- a/Contents/scripts/siweighteditor/prof.py
+++ b/Contents/scripts/siweighteditor/prof.py
@@ -44,7 +44,7 @@ class LapCounter():
             try:
                 window.time_label.setText('- Calculation Time - '+out_put_time+' sec')
             except Exception as e:
-                e.message
+                print('{}'.format(e))
                 pass
             
         if print_flag:#表示するかどうかをグローバル変数で管理

--- a/Contents/scripts/siweighteditor/siweighteditor.py
+++ b/Contents/scripts/siweighteditor/siweighteditor.py
@@ -93,7 +93,7 @@ def load_plugin():
             cmds.loadPlugin('bake_skin_weight.py', qt=True)
             cmds.pluginInfo('bake_skin_weight.py', e=True, autoload=True)
     except Exception as e:
-        'load plugin error :', e.message
+        'load plugin error :', '{}'.format(e)
     #ツールチップもついでに有効か
     cmds.help(popupMode=True)
 
@@ -518,7 +518,7 @@ class TableModel(QAbstractTableModel):
                 #指定桁数にまとめる、formatで自動的に桁数そろえてくれるみたい
                 return FLOAT_FORMAT.format(weight)
             except Exception as e:
-                #print(e.message)
+                #print('{}'.format(e))
                 return None
         elif role == Qt.BackgroundRole:#バックグラウンドロールなら色変更する
             if row in self.mesh_rows:
@@ -651,7 +651,7 @@ class OptionWindow():
             WINDOW.closeEvent(None)
             WINDOW.close()
         except Exception as e:
-            #print('window close error :', e.message)
+            #print('window close error :', '{}'.format(e))
             pass
         WINDOW = WeightEditorWindow()
         WINDOW.init_flag=False
@@ -2526,7 +2526,7 @@ class WeightEditorWindow(qt.DockWindow):
                 try:
                     cmds.deleteAttr(skin_cluster+'.'+self.lock_attr_name)
                 except Exception as e:
-                    print('clear lock error :', skin_cluster, e.message)
+                    print('clear lock error :', skin_cluster, '{}'.format(e))
                     pass
             else:
                 cmds.setAttr(skin_cluster+'.'+self.lock_attr_name, 
@@ -2694,7 +2694,7 @@ class WeightEditorWindow(qt.DockWindow):
                     try:
                         cmds.deleteAttr(skin_cluster+'.'+self.lock_attr_name)
                     except Exception as e:
-                        print('clear lock error :', skin_cluster, e.message)
+                        print('clear lock error :', skin_cluster, '{}'.format(e))
                         pass
                 else:
                     cmds.setAttr(skin_cluster+'.'+self.lock_attr_name, type='stringArray', *([len(new_lock_data_list)] + new_lock_data_list) )
@@ -2723,7 +2723,7 @@ class WeightEditorWindow(qt.DockWindow):
                         lock_data_dict[int(split_lock_data[0])] = lock_inf_str.split(',')
             return lock_data_dict
         except Exception as e:#読み込み失敗したらクリアする
-            print('decode locke data error :', e.message)
+            print('decode locke data error :', '{}'.format(e))
             return {}
                 
     #ロック状態のクリア
@@ -2738,7 +2738,7 @@ class WeightEditorWindow(qt.DockWindow):
                 try:
                     cmds.deleteAttr(skin_cluster+'.'+self.lock_attr_name)
                 except Exception as e:
-                    print('clear lock error :', skin_cluster, e.message)
+                    print('clear lock error :', skin_cluster, '{}'.format(e))
                     pass
             
     #コピペ右クリックメニュー
@@ -2994,7 +2994,7 @@ class WeightEditorWindow(qt.DockWindow):
             if cmds.selectMode(q=True, co=True) and not self.focus_but.isChecked():
                 return
         except Exception as e:
-            #print(e.message)
+            #print('{}'.format(e))
             #print('UI Allready Closed :')
             return
         if self.hilite_flag:
@@ -3246,7 +3246,7 @@ class WeightEditorWindow(qt.DockWindow):
                 try:
                     self.vtx_lock_data_dict[vtx_name].add(node_influence_id_dict[influence])
                 except Exception as e:
-                    print('lock setting error :', e.message)
+                    print('lock setting error :', '{}'.format(e))
                     pass
                    
         try:#都度メモリをきれいに
@@ -3254,19 +3254,19 @@ class WeightEditorWindow(qt.DockWindow):
             self.weight_model._data = {}
         except Exception as e:
             pass
-            #print(e.message, 'in get set' )
+            #print('{}'.format(e), 'in get set' )
         try:#都度メモリをきれいに
             self.weight_model.deleteLater()
             del self.weight_model
         except Exception as e:
             pass
-            #print(e.message, 'in get set' )
+            #print('{}'.format(e), 'in get set' )
         try:
             self.sel_model.deleteLater()
             del self.sel_model
         except Exception as e:
             pass
-            #print(e.message, 'in get set' )
+            #print('{}'.format(e), 'in get set' )
         try:
             self.weight_model = TableModel(self._data, self.view_widget, self.mesh_rows, 
                                             self.all_influences, self.v_header_list, self.inf_color_list)
@@ -3459,7 +3459,7 @@ class WeightEditorWindow(qt.DockWindow):
                 if MAYA_VER >= 2016:
                     cmds.setAttr(influence + '.overrideEnabled', 0)
             except Exception as e:
-                #print(e.message)
+                #print('{}'.format(e))
                 self.set_message(msg='- Joint Hilite Error : Override attr still locked -', error=True)
                 pass
         cmds.undoInfo(swf=True)#ヒストリを再度有効か
@@ -3485,7 +3485,7 @@ class WeightEditorWindow(qt.DockWindow):
             try:#オーバーライド設定を戻す
                 cmds.setAttr(influence + '.overrideEnabled', self.joint_override_dict[influence])
             except Exception as e:
-                #print(e.message)
+                #print('{}'.format(e))
                 self.set_message(msg='- Joint Unhilite Error : Override attr still locked -', error=True)
                 pass
             if MAYA_VER <= 2015:#2015以下はオーバーライドカラー設定も戻す
@@ -4028,7 +4028,7 @@ class WeightEditorWindow(qt.DockWindow):
             self.om_bake_skin_weight(realbake=True, ignoreundo=self.change_flag)
         except Exception as e:
             try:
-                print('Bake Skin Weight Failure :', e.message)
+                print('Bake Skin Weight Failure :', '{}'.format(e))
                 #プラグインをリロードしてリトライする
                 cmds.loadPlugin('bake_skin_weight.py', qt=True)
                 cmds.pluginInfo('bake_skin_weight.py', e=True, autoload=True)
@@ -4132,25 +4132,25 @@ class WeightEditorWindow(qt.DockWindow):
             del self.weight_model._data#一番でかいっぽい
             self.weight_model._data = {}
         except Exception as e:
-            #print(e.message, 'in close')
+            #print('{}'.format(e), 'in close')
             pass
         try:
             self.weight_model.deleteLater()
             del self.weight_model
         except Exception as e:
-            #print(e.message, 'in close')
+            #print('{}'.format(e), 'in close')
             pass
         try:
             self.sel_model.deleteLater()
             del self.sel_model
         except Exception as e:
-            #print(e.message, 'in close')
+            #print('{}'.format(e), 'in close')
             pass
         try:
             self.view_widget.deleteLater()
             del self.view_widget
         except Exception as e:
-            #print(e.message, 'in close')
+            #print('{}'.format(e), 'in close')
             pass
         
         try:
@@ -4181,7 +4181,7 @@ class WeightEditorWindow(qt.DockWindow):
             del self.vtx_weight_dict
             del self.lock_data_dict
         except Exception as e:
-            #print(e.message, 'in close')
+            #print('{}'.format(e), 'in close')
             pass
         #print('erase func data :')
             
@@ -4277,7 +4277,7 @@ def Option(x=None, y=None):
     try:
         cmds.deleteUI(TITLE+'WorkspaceControl')
     except Exception as e:
-        #print('delete ui failed :', e.message)
+        #print('delete ui failed :', '{}'.format(e))
         pass
         
     if not save_data['dockable']:

--- a/Contents/scripts/siweighteditor/smooth_setting_editor.py
+++ b/Contents/scripts/siweighteditor/smooth_setting_editor.py
@@ -22,7 +22,7 @@ class Option():
             WINDOW.closeEvent(None)
             WINDOW.close()
         except Exception as e:
-            #print(e.message)
+            #print('{}'.format(e))
             pass
         WINDOW = SubWindow()
         WINDOW.resize(300, 150)
@@ -112,7 +112,7 @@ class SubWindow(qt.SubWindow):
                 with open(self.save_file, 'r') as f:
                     save_data = json.load(f)
             except Exception as e:
-                print(e.message)
+                print('{}'.format(e))
                 save_data = self.save_default()
         else:
             save_data = self.save_default()

--- a/Contents/scripts/siweighteditor/store_skin_weight.py
+++ b/Contents/scripts/siweighteditor/store_skin_weight.py
@@ -233,7 +233,7 @@ class StoreSkinWeight():
                     clusterName = skinFn.name()
                     #print('get skin :', clusterName, dagIterator.fullPathName())
                 except Exception as e:
-                    print('get skin error in om :',e.message)
+                    print('get skin error in om :','{}'.format(e))
                 if skinFn:#見つかったらすぐ終わり
                     break
                 itDG.next()
@@ -298,7 +298,7 @@ class StoreSkinWeight():
                 #print('get weight :',meshPath , vertexComp , weights , infCountPtr)
                 skinFn.getWeights( meshPath , vertexComp , weights , infCountPtr )
             except Exception as e:
-                print('get skin weight error :', e.message)
+                print('get skin weight error :', '{}'.format(e))
                 continue
             #print('check weight data type :', type(weights))
             weights = self.conv_weight_shape(len(infIndices), weights)

--- a/Contents/scripts/siweighteditor/store_skin_weight_om2.py
+++ b/Contents/scripts/siweighteditor/store_skin_weight_om2.py
@@ -37,7 +37,7 @@ class StoreSkinWeight():
                 meshDag, component = iter.getComponent() 
                 #print('get dag node :', meshDag.fullPathName(), component)
             except Exception as e:#2016ではノード出したばかりの状態でシェイプがなぜか帰ってくるのでエラー回避
-                print('get current vtx error :', e.message)
+                print('get current vtx error :', '{}'.format(e))
                 iter.next()
                 continue
                 
@@ -91,7 +91,7 @@ class StoreSkinWeight():
                 #print('get dag node :', meshDag.fullPathName())
             except Exception as e:#2016ではノード出したばかりの状態でシェイプがなぜか帰ってくるのでエラー回避
                 #iter.next()
-                print('get dag path error1 :', e.message)
+                print('get dag path error1 :', '{}'.format(e))
                 iter.next()
                 continue
             mesh_path_name = meshDag.fullPathName()
@@ -128,7 +128,7 @@ class StoreSkinWeight():
                 #print('get dag node :', meshDag.fullPathName(), component)
             except Exception as e:#2016ではノード出したばかりの状態でシェイプがなぜか帰ってくるのでエラー回避
                 #iter.next()
-                print('get dag path error2 :', e.message)
+                print('get dag path error2 :', '{}'.format(e))
                 continue
             
             skinFn, vtxArray, skinName = self.adust_to_vertex_list(meshDag, component)
@@ -261,7 +261,7 @@ class StoreSkinWeight():
                 #print('get weight :',meshPath , vertexComp , weights , infCountPtr)
                 weights = skinFn.getWeights( meshPath , vertexComp)
             except Exception as e:
-                print('get skin weight error :', e.message)
+                print('get skin weight error :', '{}'.format(e))
                 continue
             #print('check weight data type :', type(weights))
             #print("getWeights :", weights)

--- a/Contents/scripts/siweighteditor/weight.py
+++ b/Contents/scripts/siweighteditor/weight.py
@@ -55,7 +55,7 @@ class WeightCopyPaste():
                 if not os.path.exists(self.protect_path):
                     os.makedirs(self.protect_path)
             except Exception as e:
-                print(e.message)
+                print('{}'.format(e))
                 return
             self.filePath = self.protect_pat+os.sep + self.saveName
         self.fileName = os.path.join(self.filePath, self.saveName + '.json')
@@ -109,7 +109,7 @@ class WeightCopyPaste():
                         common.TemporaryReparent().main(skinMesh, dummyParent=dummy, mode='parent')
                         tempSkinNode = skinMesh#親を取得するためスキンクラスタのあるノードを保存しておく
                     except Exception as e:
-                        print(e.message)
+                        print('{}'.format(e))
                         print('Error !! Skin bind failed : ' + skinMesh)
                         continue
             else:
@@ -380,7 +380,7 @@ def load_joint_label_rules():
                     left_list_list.append(l_list)
                     right_list_list.append(r_list)
             except Exception as e:
-                print(e.message)
+                print('{}'.format(e))
                 left_list_list.append(def_left_list_list[i])
                 right_list_list.append(def_right_list_list[i])
         else:

--- a/Contents/scripts/siweighteditor/weight_transfer_multiple.py
+++ b/Contents/scripts/siweighteditor/weight_transfer_multiple.py
@@ -194,7 +194,7 @@ class WeightTransferMultiple(qt.SubWindow):
             if len(self.dup_objs) > 1:
                 cmds.delete(self.dup_objs)
         except Exception as e:
-            e.message
+            print('{}'.format(e))
         cmds.delete(self.marged_mesh)
             
         cmds.select(self.transfer_mesh+self.transfer_comp, r=True)


### PR DESCRIPTION
Exception.message、Python 2.6では非推奨になり、Python3では削除されました。
// Error: AttributeError: file SIWeightEditor\Contents\scripts\siweighteditor\store_skin_weight_om2.py line 94: 'RuntimeError' object has no attribute 'message' //

(cherry picked from commit a9524f8d1e903bea5112e2419c9dc09445cb2087)