### PR TITLE
check_section_is_active()が常にFalseになる不具合を修正

### DIFF
--- a/Contents/scripts/siweighteditor/siweighteditor.py
+++ b/Contents/scripts/siweighteditor/siweighteditor.py
@@ -361,8 +361,7 @@ class MyHeaderView(QHeaderView):
     #現在のセクションがアクティブかどうかを判定する
     def check_section_is_active(self, index):
         sel_model = self.selectionModel()#ビューに設定されている選択モデルを取得する
-        selected_item = sel_model.currentIndex()
-        is_active = sel_model.columnIntersectsSelection(index, selected_item)
+        is_active = sel_model.columnIntersectsSelection(index, QModelIndex())
         #print('header is active :', is_active)
         return is_active
         


### PR DESCRIPTION
# 概要
https://github.com/ShikouYamaue/SIWeightEditor/issues/17 を修正いたしました。

# 確認環境
Maya2022.5

# 原因
Qtバージョンによる不具合のようでした。
具体的な内容は https://github.com/ShikouYamaue/SIWeightEditor/pull/10 と全く同じです。

# 変更
- columnIntersectsSelection()の第二引数をQModelIndex()に