### PR TITLE
check_section_is_activeが常にfalseになるバグを修正

### DIFF
--- a/Contents/scripts/siweighteditor/siweighteditor.py
+++ b/Contents/scripts/siweighteditor/siweighteditor.py
@@ -361,8 +361,11 @@ class MyHeaderView(QHeaderView):
     #現在のセクションがアクティブかどうかを判定する
     def check_section_is_active(self, index):
         sel_model = self.selectionModel()#ビューに設定されている選択モデルを取得する
-        selected_item = sel_model.currentIndex()
-        is_active = sel_model.columnIntersectsSelection(index, selected_item)
+        if MAYA_VER >= 2022:
+            is_active = sel_model.columnIntersectsSelection(index)
+        else:
+            selected_item = sel_model.currentIndex()
+            is_active = sel_model.columnIntersectsSelection(index, selected_item)
         #print('header is active :', is_active)
         return is_active
         


### PR DESCRIPTION
# 概要
- check_section_is_active()が常にfalseを返すバグを修正いたしました
- https://github.com/ShikouYamaue/SIWeightEditor/issues/17

# 確認環境
- Maya2024.2
- Maya2022.5
- Maya2018
- Maya2016Extension2

# 原因
Qtバージョンによる不具合でした。
具体的な内容は https://github.com/ShikouYamaue/SIWeightEditor/pull/10 と全く同じです。

# 変更
- 2022以降はcolumnIntersectsSelection()を第二引数なしで呼ぶように
- 2022未満はcolumnIntersectsSelection()を従来通りの処理に