### PR TITLE
Maya2025に対応

### DIFF
--- a/Contents/scripts/siweighteditor/joint_rule_editor.py
+++ b/Contents/scripts/siweighteditor/joint_rule_editor.py
@@ -5,12 +5,18 @@ import os
 import json
 import imp
 from maya.app.general.mayaMixin import MayaQWidgetBaseMixin
-try:
-    imp.find_module('PySide2')
+
+from .maya_version import MAYA_VER
+
+if MAYA_VER >= 2025:
+    from PySide6.QtWidgets import *
+    from PySide6.QtGui import *
+    from PySide6.QtCore import *
+elif 2017 <= MAYA_VER < 2025:
     from PySide2.QtWidgets import *
     from PySide2.QtGui import *
     from PySide2.QtCore import *
-except ImportError:
+else:
     from PySide.QtGui import *
     from PySide.QtCore import *
     

--- a/Contents/scripts/siweighteditor/maya_version.py
+++ b/Contents/scripts/siweighteditor/maya_version.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+from maya import cmds
+
+MAYA_VER = int(cmds.about(v=True)[:4])

--- a/Contents/scripts/siweighteditor/qt.py
+++ b/Contents/scripts/siweighteditor/qt.py
@@ -225,7 +225,10 @@ def change_widget_color(widget,
     #ウィジェットのカラー変更
     palette = QPalette()
     palette.setColor(QPalette.Button, bgColor)
-    palette.setColor(QPalette.Background, bgColor)
+    if MAYA_VER >= 2025:
+        palette.setColor(QPalette.Window, bgColor)
+    else:
+        palette.setColor(QPalette.Background, bgColor)
     palette.setColor(QPalette.Base, baseColor)
     palette.setColor(QPalette.Text, textColor)
     

--- a/Contents/scripts/siweighteditor/qt.py
+++ b/Contents/scripts/siweighteditor/qt.py
@@ -2,23 +2,25 @@
 import sys
 from maya import OpenMayaUI, cmds
 from maya.app.general.mayaMixin import MayaQWidgetDockableMixin
-#PySide2、PySide両対応
-import imp
-try:
-    imp.find_module('PySide2')
+
+from .maya_version import MAYA_VER
+
+#PySide6、PySide2、PySide全対応
+if MAYA_VER >= 2025:
+    from PySide6.QtWidgets import *
+    from PySide6.QtGui import *
+    from PySide6.QtCore import *
+    import shiboken6 as shiboken
+elif 2017 <= MAYA_VER < 2025:
     from PySide2.QtWidgets import *
     from PySide2.QtGui import *
     from PySide2.QtCore import *
-except ImportError:
+    import shiboken2 as shiboken
+else:
     from PySide.QtGui import *
     from PySide.QtCore import *
-try:
-    imp.find_module("shiboken2")
-    import shiboken2 as shiboken
-except ImportError:
     import shiboken
-    
-MAYA_VER = int(cmds.about(v=True)[:4])
+
 MAYA_API_VER = int(cmds.about(api=True))
 
 try:

--- a/Contents/scripts/siweighteditor/siweighteditor.py
+++ b/Contents/scripts/siweighteditor/siweighteditor.py
@@ -292,7 +292,7 @@ class MyHeaderView(QHeaderView):
         super(MyHeaderView, self).__init__(Qt.Horizontal, parent)
         self._font = QFont("helvetica", 9)
         self._actived_font = QFont("helvetica", 9)
-        self._actived_font.setWeight(63)#太くする
+        self._actived_font.setWeight(QFont.DemiBold)#太くする
         self._metrics = QFontMetrics(self._font)
         self._descent = self._metrics.descent()
         self._margin = 5
@@ -387,7 +387,10 @@ class MyHeaderView(QHeaderView):
     def _get_text_width(self):
         if self.model() is None:
             return 0
-        width_list = [self._metrics.width(self._get_data(i)) for i in range(0, self.model().columnCount())] or [0]
+        if MAYA_VER >= 2025:
+            width_list = [self._metrics.horizontalAdvance(self._get_data(i)) for i in range(0, self.model().columnCount())] or [0]
+        else:
+            width_list = [self._metrics.width(self._get_data(i)) for i in range(0, self.model().columnCount())] or [0]
         max_width = max(width_list) *1.1
         return max_width
 
@@ -997,9 +1000,13 @@ class WeightEditorWindow(qt.DockWindow):
         self.max_value_but_group.addButton(self.w100_but, 1)
         self.pre_max_id = round(self.max_wt/100, 1)
         self.max_value_but_group.button(self.pre_max_id).setChecked(True)
-        self.max_value_but_group.buttonClicked[int].connect(self.change_maximum_weight)
-        self.max_value_but_group.buttonClicked[int].connect(self.change_max_decimal_digit)
-        
+        if MAYA_VER >= 2025:
+            self.max_value_but_group.idClicked.connect(self.change_maximum_weight)
+            self.max_value_but_group.idClicked.connect(self.change_max_decimal_digit)
+        else:
+            self.max_value_but_group.buttonClicked[int].connect(self.change_maximum_weight)
+            self.max_value_but_group.buttonClicked[int].connect(self.change_max_decimal_digit)
+
         global MAXIMUM_WEIGHT
         MAXIMUM_WEIGHT = self.max_wt
         
@@ -1129,7 +1136,10 @@ class WeightEditorWindow(qt.DockWindow):
                             ja=u'セル選択されたジョイントをハイライトする').output()
         self.joint_hl_but = qt.make_flat_btton(name='Joint Hilite', bg=self.hilite, border_col=180, w_max=j_hl_w, w_min=j_hl_w, h_max=but_h, h_min=but_h, 
                                                             flat=True, hover=True, checkable=True, destroy_flag=True, tip=tip)
-        self.sel_joint_but_group.buttonClicked[int].connect(self.change_joint_tool_mode)
+        if MAYA_VER >= 2025:
+            self.sel_joint_but_group.idClicked.connect(self.change_joint_tool_mode)
+        else:
+            self.sel_joint_but_group.buttonClicked[int].connect(self.change_joint_tool_mode)
         self.joint_hl_but.setChecked(self.joint_hilite)
         self.joint_hl_but.clicked.connect(self.reset_joint_hl)
         self.sel_joint_but_group.addButton(self.n_but, 0)
@@ -1579,8 +1589,11 @@ class WeightEditorWindow(qt.DockWindow):
         self.norm_but.clicked.connect(self.toggle_no_limit_but_enable)
         self.norm_but.rightClicked.connect(lambda : self.enforce_limit_and_normalize(force_norm=True))
         self.no_limit_but.clicked.connect(self.keep_no_limit_flag)
-        self.mode_but_group.buttonClicked[int].connect(self.change_add_mode)
-        
+        if MAYA_VER >= 2025:
+            self.mode_but_group.idClicked.connect(self.change_add_mode)
+        else:
+            self.mode_but_group.buttonClicked[int].connect(self.change_add_mode)
+
         self.norm_but.setChecked(self.norm)
         self.no_limit_but.setChecked(self.no_limit)
         self.toggle_no_limit_but_enable()

--- a/Contents/scripts/siweighteditor/siweighteditor.py
+++ b/Contents/scripts/siweighteditor/siweighteditor.py
@@ -62,7 +62,7 @@ PYTHON_VER = sys.version_info.major
 if PYTHON_VER >= 3:
     round = common.round_half_up
 
-VERSION = 'r1.4.2'
+VERSION = 'r1.4.5'
 
 TITLE = "SIWeightEditor"
     

--- a/Contents/scripts/siweighteditor/siweighteditor.py
+++ b/Contents/scripts/siweighteditor/siweighteditor.py
@@ -24,6 +24,7 @@ import sys
 import webbrowser
 from imp import reload
 
+from .maya_version import MAYA_VER
 from . import common
 from . import lang
 from . import qt
@@ -39,17 +40,18 @@ from . import smooth_setting_editor
 reload(smooth_setting_editor)
 reload(prof)
 
-import imp
-try:
-    imp.find_module('PySide2')
+if MAYA_VER >= 2025:
+    from PySide6.QtWidgets import *
+    from PySide6.QtGui import *
+    from PySide6.QtCore import *
+elif 2017 <= MAYA_VER < 2025:
     from PySide2.QtWidgets import *
     from PySide2.QtGui import *
     from PySide2.QtCore import *
-except ImportError:
+else:
     from PySide.QtGui import *
     from PySide.QtCore import *
 
-MAYA_VER = int(cmds.about(v=True)[:4])
 
 if MAYA_VER >= 2016:
     from . import store_skin_weight_om2 as store_skin_weight

--- a/Contents/scripts/siweighteditor/smooth_setting_editor.py
+++ b/Contents/scripts/siweighteditor/smooth_setting_editor.py
@@ -3,14 +3,19 @@ from . import qt
 from . import lang
 import os
 import json
-import imp
 from maya.app.general.mayaMixin import MayaQWidgetBaseMixin
-try:
-    imp.find_module('PySide2')
+
+from .maya_version import MAYA_VER
+
+if MAYA_VER >= 2025:
+    from PySide6.QtWidgets import *
+    from PySide6.QtGui import *
+    from PySide6.QtCore import *
+elif 2017 <= MAYA_VER < 2025:
     from PySide2.QtWidgets import *
     from PySide2.QtGui import *
     from PySide2.QtCore import *
-except ImportError:
+else:
     from PySide.QtGui import *
     from PySide.QtCore import *
     

--- a/Contents/scripts/siweighteditor/weight_transfer_multiple.py
+++ b/Contents/scripts/siweighteditor/weight_transfer_multiple.py
@@ -9,6 +9,7 @@ import locale
 import json
 import copy
 
+from .maya_version import MAYA_VER
 from . import modeling
 from . import qt
 from . import common
@@ -19,18 +20,20 @@ import maya.OpenMaya as om
 import maya.OpenMayaAnim as oma
 import maya.api.OpenMaya as om2
 import maya.api.OpenMayaAnim as oma2
-#PySide2、PySide両対応
-import imp
-try:
-    imp.find_module('PySide2')
+
+#PySide6、PySide2、PySide全対応
+if MAYA_VER >= 2025:
+    from PySide6.QtWidgets import *
+    from PySide6.QtGui import *
+    from PySide6.QtCore import *
+elif 2017 <= MAYA_VER < 2025:
     from PySide2.QtWidgets import *
     from PySide2.QtGui import *
     from PySide2.QtCore import *
-except ImportError:
+else:
     from PySide.QtGui import *
     from PySide.QtCore import *
     
-MAYA_VER = int(cmds.about(v=True)[:4])
 
 if MAYA_VER >= 2016:
     from . import store_skin_weight_om2 as store_skin_weight


### PR DESCRIPTION
# 概要
- Maya2025でも動作するようにいたしました
- https://github.com/ShikouYamaue/SIWeightEditor/issues/20

# 確認環境
- Maya2025.0
- Maya2024.2
- Maya2022.5
- Maya2018
- Maya2016Extension2

# 原因
Maya2025からはPySideが6になったことによる不具合でした。

# 変更
- PySideモジュールのimportをMayaバージョンで分岐するように
- 各種PySideのバージョンを両立する書き方に