### PR TITLE
mac版のMAYAでウィンドウが後ろに入ってしまうのを修正。

### DIFF
--- a/Contents/scripts/siweighteditor/siweighteditor.py
+++ b/Contents/scripts/siweighteditor/siweighteditor.py
@@ -840,6 +840,9 @@ class WeightEditorWindow(qt.DockWindow):
         #OpenMayaでウェイト取得するクラスをインスタンス化
         self.store_skin_weight = store_skin_weight.StoreSkinWeight()
         #self.setAcceptDrops(True)#ドロップ可能にしておく
+
+        self.setObjectName("SIWeightEditorWindow")  # <- objectNameを設定
+        self.setProperty("saveWindowPref", True)  # <- ウィンドウ設定の保存を許可
         self._init_ui()
     
     show_flag = False    


### PR DESCRIPTION
WeightEditorWindowの_init_に以下の二行を追加しました。

self.setObjectName("SIWeightEditorWindow")  # <- objectNameを設定
self.setProperty("saveWindowPref", True)  # <- ウィンドウ設定の保存を許可

http://leavebehind.mydns.jp/wordpress/2016/12/14/mac版mayapysideで作成したウィンドウがメインウィンドウ/
こちら参考にしました。